### PR TITLE
Csv out

### DIFF
--- a/barcodecop/barcodecop.py
+++ b/barcodecop/barcodecop.py
@@ -172,6 +172,9 @@ def main(arguments=None):
     match_options.add_argument(
         '-c', '--show-counts', action='store_true', default=False,
         help='tabulate barcode counts and exit')
+    match_options.add_argument(
+        '-t', '--tsv-counts', type=argparse.FileType('w'),
+        help='tabulate barcode counts and store as a TSV')
 
     qual_options = parser.add_argument_group('Barcode quality filtering options')
 
@@ -220,6 +223,10 @@ def main(arguments=None):
     log.info('most common barcode: {} ({}/{} = {:.2f}%)'.format(
         most_common_bc, counts[0], sum(counts), most_common_pct))
 
+    if args.tsv_counts:
+        for bc, count in barcode_counts.most_common():
+            args.tsv_counts.write('{}\t{}\t{}\n'.format(bc, seqdiff(most_common_bc, bc), count))
+        
     if args.show_counts:
         for bc, count in barcode_counts.most_common():
             print(('{}\t{}\t{}'.format(bc, seqdiff(most_common_bc, bc), count)))

--- a/barcodecop/barcodecop.py
+++ b/barcodecop/barcodecop.py
@@ -9,6 +9,7 @@ suffix.
 
 import argparse
 import sys
+import csv
 from collections import Counter
 import logging
 from collections import namedtuple
@@ -173,8 +174,8 @@ def main(arguments=None):
         '-c', '--show-counts', action='store_true', default=False,
         help='tabulate barcode counts and exit')
     match_options.add_argument(
-        '-t', '--tsv-counts', type=argparse.FileType('w'),
-        help='tabulate barcode counts and store as a TSV')
+        '-C', '--csv-counts', type=argparse.FileType('w'), metavar='FILE',
+        help='tabulate barcode counts and store as a CSV')
 
     qual_options = parser.add_argument_group('Barcode quality filtering options')
 
@@ -223,9 +224,13 @@ def main(arguments=None):
     log.info('most common barcode: {} ({}/{} = {:.2f}%)'.format(
         most_common_bc, counts[0], sum(counts), most_common_pct))
 
-    if args.tsv_counts:
+    if args.csv_counts:
+        # Create a writer using the CSV module
+        csv_counts_writer = csv.writer(args.csv_counts)
+        # Write a header
+        csv_counts_writer.writerow(['barcode', 'diff_most_common','count'])
         for bc, count in barcode_counts.most_common():
-            args.tsv_counts.write('{}\t{}\t{}\n'.format(bc, seqdiff(most_common_bc, bc), count))
+            csv_counts_writer.writerow([bc, seqdiff(most_common_bc,bc), count])
         
     if args.show_counts:
         for bc, count in barcode_counts.most_common():


### PR DESCRIPTION
Added the option to output the barcode results as a CSV file (similar to what is logged on the screen). The CSV files are specified with the -C or --csv-counts option. A header is created for each CSV file. 