### PR TITLE
Updates for handling empty fastqs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   - "2.7"
 
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
  Changelog for barcodcop
 =========================
 
+version 0.5
+===========
+
+* handles empty files without error (GH10)
+* add ``-C/--read-counts`` to provide input and output read counts
+* rename ``-c/--show-counts`` to ``-b/--barcode-counts``
+
 version 0.4.1
 =============
 

--- a/barcodecop/barcodecop.py
+++ b/barcodecop/barcodecop.py
@@ -243,6 +243,15 @@ def main(arguments=None):
         most_common_pct = 100 * float(counts[0]) / sum(counts)
     except ZeroDivisionError:
         most_common_pct = 0
+    else:
+        if most_common_pct < args.min_pct_assignment:
+            msg = 'frequency of most common barcode is less than {}%'.format(
+                args.min_pct_assignment)
+            if args.strict:
+                log.error('Error: ' + msg)
+                sys.exit(1)
+            else:
+                log.warning('Warning: ' + msg)
 
     log.info('most common barcode: {} ({}/{} = {:.2f}%)'.format(
         most_common_bc, counts[0], sum(counts), most_common_pct))
@@ -259,15 +268,6 @@ def main(arguments=None):
         for bc, count in barcode_counts.most_common():
             print(('{}\t{}\t{}'.format(bc, seqdiff(most_common_bc, bc), count)))
         return None
-
-    if most_common_pct < args.min_pct_assignment:
-        msg = 'frequency of most common barcode is less than {}%'.format(
-            args.min_pct_assignment)
-        if args.strict:
-            log.error('Error: ' + msg)
-            sys.exit(1)
-        else:
-            log.warning('Warning: ' + msg)
 
     ifilterfun = filterfalse if args.invert else filter
 

--- a/barcodecop/barcodecop.py
+++ b/barcodecop/barcodecop.py
@@ -194,7 +194,8 @@ def main(arguments=None):
 
     qual_options.add_argument(
         '--qual-filter', action='store_true', default=False,
-        help='filter reads based on minimum index quality [default: no quality filter]')
+        help=('filter reads based on minimum index quality '
+              '[default: no quality filter]'))
     qual_options.add_argument(
         '-p', '--min-qual', type=int, default=MIN_QUAL,
         help="""reject seqs with mean barcode quality score less than
@@ -209,7 +210,7 @@ def main(arguments=None):
 
     logging.basicConfig(
         format='%(message)s',
-        level=logging.ERROR if args.quiet else logging.INFO)
+        level=logging.ERROR if args.quiet else logging.WARNING)
     log = logging.getLogger(__name__)
 
     # when provided with dual barcodes, concatenate into a single

--- a/barcodecop/barcodecop.py
+++ b/barcodecop/barcodecop.py
@@ -272,8 +272,8 @@ def main(arguments=None):
 
     if args.read_counts:
         filtered, filtered2 = tee(filtered)
-        input_count = len(list(seqs2))
-        output_count = len(list(filtered2))
+        input_count = sum(1 for _ in seqs2)
+        output_count = sum(1 for _ in filtered2)
         read_counts_writer = csv.writer(args.read_counts)
         read_counts_writer.writerow([args.outfile.name, input_count, output_count])
 

--- a/barcodecop/barcodecop.py
+++ b/barcodecop/barcodecop.py
@@ -127,6 +127,14 @@ def combine_dual_indices(file1, file2):
         yield Seq(id=i1.id, seq=i1.seq + '+' + i2.seq, qual=i1.qual, qual2=i2.qual)
 
 
+def close_all_files(args):
+    for name, obj in args.__dict__.items():
+        if (obj and hasattr(obj, 'close') and
+            hasattr(obj, 'closed') and hasattr(obj, 'name')):
+            if not obj.closed:
+                obj.close()
+
+
 def main(arguments=None):
     parser = argparse.ArgumentParser(
         prog='barcodecop', description=__doc__,
@@ -283,6 +291,8 @@ def main(arguments=None):
     for seq, bc in islice(filtered, args.head):
         assert seq.id == bc.id
         args.outfile.write(as_fastq(seq))
+
+    close_all_files(args)
 
 
 if __name__ == '__main__':

--- a/barcodecop/barcodecop.py
+++ b/barcodecop/barcodecop.py
@@ -230,7 +230,10 @@ def main(arguments=None):
     barcodes, counts = list(zip(*barcode_counts.most_common()))
 
     most_common_bc = barcodes[0]
-    most_common_pct = 100 * float(counts[0]) / (sum(counts) or 1)
+    try:
+        most_common_pct = 100 * float(counts[0]) / sum(counts)
+    except ZeroDivisionError:
+        most_common_pct = 0
 
     log.info('most common barcode: {} ({}/{} = {:.2f}%)'.format(
         most_common_bc, counts[0], sum(counts), most_common_pct))

--- a/tests/test.py
+++ b/tests/test.py
@@ -114,16 +114,6 @@ class TestSingleIndex(TestCase):
                 main,
                 [barcodes, '-f', barcodes, '--min-pct-assignment', '100', '--strict'])
 
-    def test_07(self):
-        # test error on empty file
-        with Capturing():
-            self.assertRaises(SystemExit, main, [empty, '-f', empty])
-
-    def test_08(self):
-        # no error on empty file with --allow-empty
-        with Capturing():
-            main([empty, '-f', empty, '--allow-empty'])
-
     def test_qual_01(self):
         # test quality filtering with defaults
         with Capturing() as output:


### PR DESCRIPTION
* Changed --csv-counts to --barcode-counts
* Added --read-counts CSV R-path,input-count,output-count
* Various structural updates to handle empty fastqs

Question: Do we need --show-counts anymore or is that mostly handled by --barcode-counts?